### PR TITLE
Ensure connection always get properly initialized.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+3.2 (unreleased)
+----------------
+
+- Add support for reading the connection string from an environemt variable.
+  Use ``ENV:DB_CONN`` as connection string to look up the actual connection
+  string in the environment variable ``DB_CONN``.
+
+- Ensure connection always get properly initialized.
+
+- Add support for PostgreSQL 13.
+
+
 3.1 (2023-01-16)
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,8 @@ setup(
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     install_requires=[
         'setuptools',
-        'psycopg2; python_version>="3.6"',
-        'psycopg2 < 2.9; python_version<="3.5"',
+        'psycopg2 >= 2.4.2; python_version>="3.6"',
+        'psycopg2 >= 2.4.2, < 2.9; python_version<="3.5"',
         'Zope',
         'Products.ZSQLMethods',
     ],


### PR DESCRIPTION
Previously it was possible that `getcursor` might get a connection which was not correctly initialized. This occurred when the last connection in the pool got closed before calling `getcursor`. As in this case the code guarded by `init` in `getconn` was not called.

Add support for PostgreSQL 13. (It might raise InterfaceError exceptions)

Das sollte das Problem lösen, dass ein Datumswert manchmal als `datetime.date` statt `DateTime` zurück kommt.

Upstream-PR: https://github.com/dataflake/Products.ZPsycopgDA/pull/3